### PR TITLE
dnsrecord update函数补充缺失的retry

### DIFF
--- a/alicloud/resource_alicloud_alidns_record.go
+++ b/alicloud/resource_alicloud_alidns_record.go
@@ -215,10 +215,21 @@ func resourceAlicloudAlidnsRecordUpdate(d *schema.ResourceData, meta interface{}
 	updateDomainRecordRemarkReq.Remark = d.Get("remark").(string)
 	updateDomainRecordRemarkReq.UserClientIp = d.Get("user_client_ip").(string)
 	if update {
-		raw, err := client.WithAlidnsClient(func(alidnsClient *alidns.Client) (interface{}, error) {
-			return alidnsClient.UpdateDomainRecordRemark(updateDomainRecordRemarkReq)
+		wait := incrementalWait(3*time.Second, 3*time.Second)
+		err := resource.Retry(client.GetRetryTimeout(d.Timeout(schema.TimeoutUpdate)), func() *resource.RetryError {
+			raw, err := client.WithAlidnsClient(func(alidnsClient *alidns.Client) (interface{}, error) {
+				return alidnsClient.UpdateDomainRecordRemark(updateDomainRecordRemarkReq)
+			})
+			if err != nil {
+				if IsExpectedErrors(err, []string{"LastOperationNotFinished"}) || NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			addDebug(updateDomainRecordRemarkReq.GetActionName(), raw)
+			return nil
 		})
-		addDebug(updateDomainRecordRemarkReq.GetActionName(), raw)
 		if err != nil {
 			return WrapErrorf(err, DefaultErrorMsg, d.Id(), updateDomainRecordRemarkReq.GetActionName(), AlibabaCloudSdkGoERROR)
 		}
@@ -257,10 +268,21 @@ func resourceAlicloudAlidnsRecordUpdate(d *schema.ResourceData, meta interface{}
 	updateDomainRecordReq.TTL = requests.NewInteger(d.Get("ttl").(int))
 	updateDomainRecordReq.UserClientIp = d.Get("user_client_ip").(string)
 	if update {
-		raw, err := client.WithAlidnsClient(func(alidnsClient *alidns.Client) (interface{}, error) {
-			return alidnsClient.UpdateDomainRecord(updateDomainRecordReq)
+		wait := incrementalWait(3*time.Second, 3*time.Second)
+		err := resource.Retry(client.GetRetryTimeout(d.Timeout(schema.TimeoutUpdate)), func() *resource.RetryError {
+			raw, err := client.WithAlidnsClient(func(alidnsClient *alidns.Client) (interface{}, error) {
+				return alidnsClient.UpdateDomainRecord(updateDomainRecordReq)
+			})
+			if err != nil {
+				if IsExpectedErrors(err, []string{"LastOperationNotFinished"}) || NeedRetry(err) {
+					wait()
+					return resource.RetryableError(err)
+				}
+				return resource.NonRetryableError(err)
+			}
+			addDebug(updateDomainRecordReq.GetActionName(), raw)
+			return nil
 		})
-		addDebug(updateDomainRecordReq.GetActionName(), raw)
 		if err != nil {
 			return WrapErrorf(err, DefaultErrorMsg, d.Id(), updateDomainRecordReq.GetActionName(), AlibabaCloudSdkGoERROR)
 		}


### PR DESCRIPTION
# 背景
* 阿里云dns操作会有并发限制，可能会有 `LastOperationNotFinished` 报错
* 阿里云dns record资源的update函数内部分操作没有对这个报错进行重试

# 方案
阿里云dns record资源的update函数内补全缺失的retry

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 为更新阿里云DNS服务中的域名记录和备注引入了重试机制，具有递增等待时间。
  - 调整了更新操作的错误处理和调试日志记录。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->