### PR TITLE
添加快速查询资源

### DIFF
--- a/alicloud/provider.go
+++ b/alicloud/provider.go
@@ -992,6 +992,7 @@ func Provider() terraform.ResourceProvider {
 			"alicloud_log_alert":                                             resourceAlicloudLogAlert(),
 			"alicloud_log_audit":                                             resourceAlicloudLogAudit(),
 			"alicloud_log_dashboard":                                         resourceAlicloudLogDashboard(),
+			"alicloud_log_saved_search":                                      resourceAlicloudLogSavedSearch(),
 			"alicloud_log_etl":                                               resourceAlicloudLogETL(),
 			"alicloud_log_ingestion":                                         resourceAlicloudLogIngestion(),
 			"alicloud_log_machine_group":                                     resourceAlicloudLogMachineGroup(),

--- a/alicloud/resource_alicloud_log_saved_search.go
+++ b/alicloud/resource_alicloud_log_saved_search.go
@@ -1,0 +1,194 @@
+package alicloud
+
+import (
+	"fmt"
+	"time"
+
+	sls "github.com/aliyun/aliyun-log-go-sdk"
+	"github.com/aliyun/terraform-provider-alicloud/alicloud/connectivity"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func resourceAlicloudLogSavedSearch() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAlicloudLogSavedSearchCreate,
+		Read:   resourceAlicloudLogSavedSearchRead,
+		Update: resourceAlicloudLogSavedSearchUpdate,
+		Delete: resourceAlicloudLogSavedSearchDelete,
+
+		Schema: map[string]*schema.Schema{
+			"project_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"log_store_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"display_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"topic": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"query": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func resourceAlicloudLogSavedSearchCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	logService := LogService{client}
+	var requestInfo *sls.Client
+
+	savedSearch := sls.SavedSearch{
+		SavedSearchName: d.Get("name").(string),
+		DisplayName:     d.Get("display_name").(string),
+		SearchQuery:     d.Get("query").(string),
+		Logstore:        d.Get("log_store_name").(string),
+	}
+
+	if v, ok := d.GetOk("topic"); ok {
+		savedSearch.Topic = v.(string)
+	}
+
+	if err := resource.Retry(2*time.Minute, func() *resource.RetryError {
+		_, err := client.WithLogClient(func(slsClient *sls.Client) (interface{}, error) {
+			return nil, slsClient.CreateSavedSearch(d.Get("project_name").(string), &savedSearch)
+		})
+		if err != nil {
+			if IsExpectedErrors(err, []string{LogClientTimeout}) {
+				time.Sleep(5 * time.Second)
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		addDebug("CreateSavedSearch", savedSearch, requestInfo, map[string]interface{}{
+			"savedSearch": savedSearch,
+		})
+		// 此处的 WaitForSavedSearch 用于确保创建成功， PUBLSHED 在此处为占位符，实际上只要不是 DELETED 即可
+		if err := logService.WaitForSavedSearch(d.Get("project_name").(string), d.Get("name").(string), PUBLISHED, DefaultTimeout); err != nil {
+			return resource.NonRetryableError(err)
+		}
+		d.SetId(fmt.Sprintf("%s%s%s", d.Get("project_name").(string), COLON_SEPARATED, d.Get("name").(string)))
+		return nil
+	}); err != nil {
+		return WrapErrorf(err, DefaultErrorMsg, "alicloud_log_savedsearch", "CreateSavedSearch", AliyunLogGoSdkERROR)
+	}
+	return resourceAlicloudLogSavedSearchRead(d, meta)
+}
+
+func resourceAlicloudLogSavedSearchRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	logService := LogService{client}
+	parts, err := ParseResourceId(d.Id(), 2)
+	if err != nil {
+		return WrapError(err)
+	}
+	object, err := logService.DescribeSavedSearch(parts[0], parts[1])
+	if err != nil {
+		if NotFoundError(err) {
+			d.SetId("")
+			return nil
+		}
+		return WrapError(err)
+	}
+
+	d.Set("project_name", parts[0])
+	d.Set("name", object.SavedSearchName)
+	d.Set("display_name", object.DisplayName)
+	d.Set("log_store_name", object.Logstore)
+	d.Set("query", object.SearchQuery)
+	d.Set("topic", object.Topic)
+
+	return nil
+}
+
+// here
+func resourceAlicloudLogSavedSearchUpdate(d *schema.ResourceData, meta interface{}) error {
+	parts, err := ParseResourceId(d.Id(), 2)
+	if err != nil {
+		return WrapError(err)
+	}
+
+	update := false
+	if d.HasChange("display_name") {
+		update = true
+	}
+	if d.HasChange("topic") {
+		update = true
+	}
+	if d.HasChange("query") {
+		update = true
+	}
+
+	if update {
+		client := meta.(*connectivity.AliyunClient)
+		savedSearch := sls.SavedSearch{
+			SavedSearchName: d.Get("name").(string),
+			DisplayName:     d.Get("display_name").(string),
+			SearchQuery:     d.Get("query").(string),
+			Logstore:        d.Get("log_store_name").(string),
+		}
+
+		if v, ok := d.GetOk("topic"); ok {
+			savedSearch.Topic = v.(string)
+		}
+
+		_, err = client.WithLogClient(func(slsClient *sls.Client) (interface{}, error) {
+			return nil, slsClient.UpdateSavedSearch(parts[0], &savedSearch)
+		})
+		if err != nil {
+			return WrapErrorf(err, DefaultErrorMsg, d.Id(), "UpdateSavedSearch", AliyunLogGoSdkERROR)
+		}
+	}
+	return resourceAlicloudLogSavedSearchRead(d, meta)
+}
+
+func resourceAlicloudLogSavedSearchDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*connectivity.AliyunClient)
+	logService := LogService{client}
+	parts, err := ParseResourceId(d.Id(), 2)
+	if err != nil {
+		return WrapError(err)
+	}
+	var requestInfo *sls.Client
+	err = resource.Retry(3*time.Minute, func() *resource.RetryError {
+		raw, err := client.WithLogClient(func(slsClient *sls.Client) (interface{}, error) {
+			requestInfo = slsClient
+			return nil, slsClient.DeleteSavedSearch(parts[0], parts[1])
+		})
+		if err != nil {
+			if IsExpectedErrors(err, []string{LogClientTimeout, "RequestTimeout"}) {
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		addDebug("DeleteSavedSearch", raw, requestInfo, map[string]interface{}{
+			"project_name":      parts[0],
+			"saved_search_name": parts[1],
+		})
+		return nil
+	})
+	if err != nil {
+		if IsExpectedErrors(err, []string{"SavedSearchNotExist", "ProjectNotExist"}) {
+			return nil
+		}
+		return WrapErrorf(err, DefaultErrorMsg, d.Id(), "DeleteSavedSearch", AliyunLogGoSdkERROR)
+	}
+	return WrapError(logService.WaitForSavedSearch(parts[0], parts[1], Deleted, DefaultTimeout))
+}

--- a/website/docs/r/log_saved_search.html.markdown
+++ b/website/docs/r/log_saved_search.html.markdown
@@ -1,0 +1,55 @@
+---
+subcategory: "Log Service (SLS)"
+layout: "alicloud"
+page_title: "Alicloud: alicloud_log_saved_search"
+sidebar_current: "docs-alicloud-resource-log-saved-search"
+description: |-
+  Provides a Alicloud Log Saved Search resource.
+---
+
+# alicloud\_log\_saved\_search
+Simple Log Service provides the saved search feature to save the required data query and analysis operations. You can use a saved search to quickly perform query and analysis operations.
+[Refer to details](https://www.alibabacloud.com/help/en/sls/user-guide/saved-search).
+
+-> **NOTE:** Available in 1.201.9 (ShinnyTech forked version only)
+
+## Example Usage
+
+Basic Usage
+
+```terraform
+resource "alicloud_log_project" "default" {
+  name        = "tf-project"
+  description = "tf unit test"
+}
+resource "alicloud_log_store" "default" {
+  project          = "tf-project"
+  name             = "tf-logstore"
+  retention_period = "3000"
+  shard_count      = 1
+}
+resource "alicloud_log_saved_search" "example" {
+  project_name   = "tf-project"
+  log_store_name = "tf-logstore"
+  display_name   = "tf-saved-search"
+  query          = "* | select * from log"
+}
+```
+
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `project_name` - (Required, ForceNew) The name of the log project. It is the only in one Alicloud account.
+* `name` - (Required, ForceNew) The name of the saved search. It is unique in the project.
+* `log_store_name` - (Required, ForceNew) The name of the logstore.
+* `display_name` - (Required) The display name of the saved search.
+* `topic` - (Optional) The topic of the saved search.
+* `query` - (Required) The query statement of the saved search.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the SavedSearch.


### PR DESCRIPTION
# 背景
cdk项目需要添加快速查询，但是官方terraform插件里并未提供相关资源

# 方案
依靠sdk已有的快速查询相关接口，参照logdashboard的相关代码结构新增快速查询资源

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 添加了 `alicloud_log_saved_search` 资源，用于管理阿里云日志服务中的已保存搜索功能。

- **文档**
  - 在网站文档中添加了有关 `alicloud_log_saved_search` 资源的使用指南，包括创建和使用已保存搜索进行查询和分析操作的说明。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->