### PR TITLE
固定goreleaser版本为1.26.2

### DIFF
--- a/.github/workflows/shinny_release.yml
+++ b/.github/workflows/shinny_release.yml
@@ -40,7 +40,7 @@ jobs:
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4
         with:
-          version: latest
+          version: 1.26.2
           args: release --clean --timeout 500m --parallelism 1 --config .goreleaser.shinny.yml ${{ env.grflags }}
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}


### PR DESCRIPTION
# 背景
打包时发现releaser的版本更新到了2.x，导致现有的配置文件解析失败

# 方案
固定releaser版本为1.26.2，此版本为action记录中上一次成功的版本

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - 更新了 GoReleaser 操作的版本，从 `latest` 更新为 `1.26.2`。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->