### PR TITLE
dns record添加随机等待时间避免thundering herd

### DIFF
--- a/.github/workflows/acctest-terraform-basic.yml
+++ b/.github/workflows/acctest-terraform-basic.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Get dependencies
         run: |
-          go install golang.org/x/tools/cmd/goimports@latest
+          go install golang.org/x/tools/cmd/goimports@v0.3.0
           go mod tidy
 
       - name: fmtcheck

--- a/alicloud/resource_alicloud_alidns_record.go
+++ b/alicloud/resource_alicloud_alidns_record.go
@@ -3,6 +3,7 @@ package alicloud
 import (
 	"fmt"
 	"log"
+	"math/rand"
 	"strconv"
 	"time"
 
@@ -114,14 +115,15 @@ func resourceAlicloudAlidnsRecordCreate(d *schema.ResourceData, meta interface{}
 		request.UserClientIp = v.(string)
 	}
 	request.Value = d.Get("value").(string)
-	wait := incrementalWait(3*time.Second, 10*time.Second)
 	err := resource.Retry(client.GetRetryTimeout(d.Timeout(schema.TimeoutCreate)), func() *resource.RetryError {
 		raw, err := client.WithAlidnsClient(func(alidnsClient *alidns.Client) (interface{}, error) {
 			return alidnsClient.AddDomainRecord(request)
 		})
 		if err != nil {
 			if IsExpectedErrors(err, []string{"InternalError", "LastOperationNotFinished"}) || NeedRetry(err) {
-				wait()
+				// Avoid thundering herd problem using random sleep
+				// Api server has operation lock by domain+rr
+				time.Sleep(time.Duration(rand.Int63n(time.Second.Nanoseconds())))
 				return resource.RetryableError(err)
 			}
 			return resource.NonRetryableError(err)
@@ -183,14 +185,14 @@ func resourceAlicloudAlidnsRecordUpdate(d *schema.ResourceData, meta interface{}
 	}
 	request.UserClientIp = d.Get("user_client_ip").(string)
 	if update {
-		wait := incrementalWait(3*time.Second, 3*time.Second)
 		err := resource.Retry(client.GetRetryTimeout(d.Timeout(schema.TimeoutUpdate)), func() *resource.RetryError {
 			raw, err := client.WithAlidnsClient(func(alidnsClient *alidns.Client) (interface{}, error) {
 				return alidnsClient.SetDomainRecordStatus(request)
 			})
 			if err != nil {
 				if IsExpectedErrors(err, []string{"LastOperationNotFinished"}) || NeedRetry(err) {
-					wait()
+					// Avoid thundering herd problem using random sleep
+					time.Sleep(time.Duration(rand.Int63n(time.Second.Nanoseconds())))
 					return resource.RetryableError(err)
 				}
 				return resource.NonRetryableError(err)
@@ -215,14 +217,14 @@ func resourceAlicloudAlidnsRecordUpdate(d *schema.ResourceData, meta interface{}
 	updateDomainRecordRemarkReq.Remark = d.Get("remark").(string)
 	updateDomainRecordRemarkReq.UserClientIp = d.Get("user_client_ip").(string)
 	if update {
-		wait := incrementalWait(3*time.Second, 3*time.Second)
 		err := resource.Retry(client.GetRetryTimeout(d.Timeout(schema.TimeoutUpdate)), func() *resource.RetryError {
 			raw, err := client.WithAlidnsClient(func(alidnsClient *alidns.Client) (interface{}, error) {
 				return alidnsClient.UpdateDomainRecordRemark(updateDomainRecordRemarkReq)
 			})
 			if err != nil {
 				if IsExpectedErrors(err, []string{"LastOperationNotFinished"}) || NeedRetry(err) {
-					wait()
+					// Avoid thundering herd problem using random sleep
+					time.Sleep(time.Duration(rand.Int63n(time.Second.Nanoseconds())))
 					return resource.RetryableError(err)
 				}
 				return resource.NonRetryableError(err)
@@ -268,14 +270,14 @@ func resourceAlicloudAlidnsRecordUpdate(d *schema.ResourceData, meta interface{}
 	updateDomainRecordReq.TTL = requests.NewInteger(d.Get("ttl").(int))
 	updateDomainRecordReq.UserClientIp = d.Get("user_client_ip").(string)
 	if update {
-		wait := incrementalWait(3*time.Second, 3*time.Second)
 		err := resource.Retry(client.GetRetryTimeout(d.Timeout(schema.TimeoutUpdate)), func() *resource.RetryError {
 			raw, err := client.WithAlidnsClient(func(alidnsClient *alidns.Client) (interface{}, error) {
 				return alidnsClient.UpdateDomainRecord(updateDomainRecordReq)
 			})
 			if err != nil {
 				if IsExpectedErrors(err, []string{"LastOperationNotFinished"}) || NeedRetry(err) {
-					wait()
+					// Avoid thundering herd problem using random sleep
+					time.Sleep(time.Duration(rand.Int63n(time.Second.Nanoseconds())))
 					return resource.RetryableError(err)
 				}
 				return resource.NonRetryableError(err)
@@ -307,14 +309,14 @@ func resourceAlicloudAlidnsRecordDelete(d *schema.ResourceData, meta interface{}
 	if v, ok := d.GetOk("user_client_ip"); ok {
 		request.UserClientIp = v.(string)
 	}
-	wait := incrementalWait(3*time.Second, 10*time.Second)
 	err := resource.Retry(client.GetRetryTimeout(d.Timeout(schema.TimeoutDelete)), func() *resource.RetryError {
 		raw, err := client.WithAlidnsClient(func(alidnsClient *alidns.Client) (interface{}, error) {
 			return alidnsClient.DeleteDomainRecord(request)
 		})
 		if err != nil {
 			if IsExpectedErrors(err, []string{"InternalError", "RecordForbidden.DNSChange", "LastOperationNotFinished"}) || NeedRetry(err) {
-				wait()
+				// Avoid thundering herd problem using random sleep
+				time.Sleep(time.Duration(rand.Int63n(time.Second.Nanoseconds())))
 				return resource.RetryableError(err)
 			}
 			return resource.NonRetryableError(err)


### PR DESCRIPTION
阿里云dns record的操作根据 domain + rr 字段进行操作锁限制，同一个 domain 同一个 rr 同时只能有一个操作进行。
在上一个操作未成功的时候发起针对被lock资源的变更会触发 LastOperationNotFinished。
以前的代码中如出现多个资源操作同一个 domain + rr 的记录会导致多个记录同时等待同时唤醒，会发生 `thundering herd`。
因此引入随机的等待时间解决 `thundering herd`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - 优化了错误重试机制，采用随机延迟策略降低了同时重试API调用时的冲击，从而提升了DNS记录操作的稳定性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->