### PR TITLE
eni: mark security_group_ids as set instead of list as the order doesn't matter

### DIFF
--- a/alicloud/resource_alicloud_ecs_network_interface.go
+++ b/alicloud/resource_alicloud_ecs_network_interface.go
@@ -107,7 +107,7 @@ func resourceAlicloudEcsNetworkInterface() *schema.Resource {
 				ConflictsWith: []string{"secondary_private_ip_address_count", "private_ip_addresses", "private_ips"},
 			},
 			"security_group_ids": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Computed: true,
 				Elem: &schema.Schema{


### PR DESCRIPTION
since only the priority of individuals rule is honored

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改进**
  - 优化了安全组 ID（security_group_ids）属性的处理方式，提升了数据的唯一性和一致性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->