### PR TITLE
eni: fix security_group_ids can't be serialized

### DIFF
--- a/alicloud/resource_alicloud_ecs_network_interface.go
+++ b/alicloud/resource_alicloud_ecs_network_interface.go
@@ -204,7 +204,7 @@ func resourceAlicloudEcsNetworkInterfaceCreate(d *schema.ResourceData, meta inte
 	}
 
 	if v, ok := d.GetOk("security_group_ids"); ok {
-		request["SecurityGroupIds"] = v
+		request["SecurityGroupIds"] = v.(*schema.Set).List()
 	} else if v, ok := d.GetOk("security_groups"); ok {
 		request["SecurityGroupIds"] = v
 	}
@@ -339,7 +339,7 @@ func resourceAlicloudEcsNetworkInterfaceUpdate(d *schema.ResourceData, meta inte
 	}
 	if d.HasChange("security_group_ids") {
 		update = true
-		request["SecurityGroupId"] = d.Get("security_group_ids")
+		request["SecurityGroupId"] = d.Get("security_group_ids").(*schema.Set).List()
 	}
 	if d.HasChange("security_groups") {
 		update = true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **修复问题**
  - 修正了在创建和更新ECS网络接口时，安全组ID属性的处理方式，确保安全组ID以列表形式正确传递。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->