### PR TITLE
suppress unexpected sql_collector_config_value diff

### DIFF
--- a/alicloud/resource_alicloud_db_instance.go
+++ b/alicloud/resource_alicloud_db_instance.go
@@ -348,6 +348,10 @@ func resourceAlicloudDBInstance() *schema.Resource {
 				Optional:     true,
 				ValidateFunc: validation.IntInSlice([]int{30, 180, 365, 1095, 1825}),
 				Default:      30,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					// if sql_collector_status is disabled, it needs to be suppressed.
+					return d.Get("sql_collector_status").(string) == "Disabled"
+				},
 			},
 			"resource_group_id": {
 				Type:     schema.TypeString,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **修复问题**
  - 当 SQL Collector 状态为“已禁用”时，忽略 sql_collector_config_value 字段的变更，避免无效的配置差异。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->